### PR TITLE
Add BLE stream support

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,12 +1,34 @@
 set(JAC_ESP32_VERSION "0.0.17")
 
+# Base source files
+set(COMPONENT_SRCS
+    "main.cpp"
+    "platform/espWifi.cpp"
+    "platform/espNvsKeyValue.cpp"
+    "espFeatures/gridui/gridUiFeature.cpp"
+    "espFeatures/gridui/widgets/_common.cpp"
+)
+
+# Base requirements
+set(COMPONENT_REQUIRES
+    jac-dcore jac-machine jac-link
+    driver pthread spiffs vfs fatfs
+    SmartLeds esp_timer Esp32-RBGridUI
+)
+
+# Conditionally add BLE support
+if(CONFIG_JAC_ESP32_ENABLE_BLE)
+    list(APPEND COMPONENT_SRCS "util/bleStream.cpp")
+    list(APPEND COMPONENT_REQUIRES "bt")
+    message(STATUS "BLE Stream support enabled")
+else()
+    message(STATUS "BLE Stream support disabled")
+endif()
+
 idf_component_register(
-    SRCS "main.cpp" "platform/espWifi.cpp" "platform/espNvsKeyValue.cpp"
-        "espFeatures/gridui/gridUiFeature.cpp" "espFeatures/gridui/widgets/_common.cpp"
+    SRCS ${COMPONENT_SRCS}
     INCLUDE_DIRS ""
-    REQUIRES jac-dcore jac-machine jac-link
-             driver pthread spiffs vfs fatfs
-             SmartLeds esp_timer Esp32-RBGridUI bt
+    REQUIRES ${COMPONENT_REQUIRES}
 )
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE JAC_ESP32_VERSION="${JAC_ESP32_VERSION}")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -6,7 +6,7 @@ idf_component_register(
     INCLUDE_DIRS ""
     REQUIRES jac-dcore jac-machine jac-link
              driver pthread spiffs vfs fatfs
-             SmartLeds esp_timer Esp32-RBGridUI
+             SmartLeds esp_timer Esp32-RBGridUI bt
 )
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE JAC_ESP32_VERSION="${JAC_ESP32_VERSION}")

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,69 @@
+menu "Jaculus ESP32 Configuration"
+
+    config JAC_ESP32_ENABLE_BLE
+        bool "Enable BLE Stream Support"
+        default y
+        help
+            Enable BLE (Bluetooth Low Energy) stream support for wireless communication.
+            This allows the ESP32 to act as a BLE GATT server that can be used
+            as a communication transport alongside UART, TCP, and JTAG streams.
+
+            When enabled:
+            - BLE stack will be initialized
+            - GATT server with custom service will be created
+            - Device will be discoverable as "ESP32_JAC_BLE_XXXX" (XXXX = MAC suffix)
+            - BLE stream will be available on mux channel 4
+
+            When disabled:
+            - BLE functionality is completely removed from build
+            - Reduces binary size and memory usage
+            - BT component dependency is optional
+
+    config JAC_ESP32_BLE_DEVICE_NAME
+        string "BLE Device Name Prefix"
+        depends on JAC_ESP32_ENABLE_BLE
+        default "ESP32_JAC_BLE"
+        help
+            The prefix for the BLE device name. The actual device name will be
+            this prefix followed by the last 2 bytes of the MAC address.
+            For example: "ESP32_JAC_BLE_A1B2"
+
+    config JAC_ESP32_BLE_SERVICE_UUID
+        hex "BLE GATT Service UUID (16-bit)"
+        depends on JAC_ESP32_ENABLE_BLE
+        default 0x00FF
+        range 0x0001 0xFFFE
+        help
+            The 16-bit UUID for the custom BLE GATT service.
+            Default is 0x00FF (255 in decimal).
+
+    config JAC_ESP32_BLE_CHARACTERISTIC_UUID
+        hex "BLE GATT Characteristic UUID (16-bit)"
+        depends on JAC_ESP32_ENABLE_BLE
+        default 0xFF01
+        range 0x0001 0xFFFE
+        help
+            The 16-bit UUID for the BLE GATT characteristic used for data transfer.
+            Default is 0xFF01 (65281 in decimal).
+
+    config JAC_ESP32_BLE_MTU_SIZE
+        int "BLE MTU Size"
+        depends on JAC_ESP32_ENABLE_BLE
+        default 500
+        range 23 512
+        help
+            Maximum Transmission Unit (MTU) size for BLE communication.
+            Larger values allow more data per packet but may not be supported
+            by all devices. Default is 500 bytes.
+
+    config JAC_ESP32_BLE_DEBUG_LOGS
+        bool "Enable BLE Debug Logging"
+        depends on JAC_ESP32_ENABLE_BLE
+        default n
+        help
+            Enable detailed debug logging for BLE operations.
+            This will show step-by-step initialization, connection events,
+            and data transfer details. Useful for debugging but increases
+            log output significantly.
+
+endmenu

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -34,7 +34,9 @@
 
 #include "util/uartStream.h"
 #include "util/tcpStream.h"
+#ifdef CONFIG_JAC_ESP32_ENABLE_BLE
 #include "util/bleStream.h"
+#endif
 
 #include "resources/resources.h"
 
@@ -125,7 +127,9 @@ jac::Device<Machine> device(
 using Mux_t = jac::Mux<jac::CobsEncoder>;
 std::unique_ptr<Mux_t> muxUart;
 std::unique_ptr<Mux_t> muxTcp;
+#ifdef CONFIG_JAC_ESP32_ENABLE_BLE
 std::unique_ptr<Mux_t> muxBle;
+#endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
     std::unique_ptr<Mux_t> muxJtag;
@@ -216,6 +220,7 @@ int main() {
         muxTcp->bindRx(std::make_unique<decltype(handleTcp)>(std::move(handleTcp)));
     }
 
+#ifdef CONFIG_JAC_ESP32_ENABLE_BLE
     // initialize BLE stream
     auto bleStream = std::make_unique<BleStream>("ESP32_JAC_BLE");
     bleStream->start();
@@ -224,6 +229,7 @@ int main() {
     muxBle->setErrorHandler(reportMuxError);
     auto handleBle = device.router().subscribeTx(4, *muxBle);
     muxBle->bindRx(std::make_unique<decltype(handleBle)>(std::move(handleBle)));
+#endif
 
 
     device.onConfigureMachine([&](Machine &machine) {

--- a/main/resources/CMakeLists.txt
+++ b/main/resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(ts_examples_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../ts-examples)
 set(ts_examples_tgz ts_examples.tar.gz)

--- a/main/util/bleStream.cpp
+++ b/main/util/bleStream.cpp
@@ -81,7 +81,7 @@ void BleStream::start() {
     }
 
     // Set MTU
-    esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
+    esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(MAX_CHUNK_SIZE);
     if (local_mtu_ret) {
         BLE_LOG_ERROR("Set local MTU failed: " + std::string(esp_err_to_name(local_mtu_ret)));
     }

--- a/main/util/bleStream.cpp
+++ b/main/util/bleStream.cpp
@@ -1,0 +1,410 @@
+#include "bleStream.h"
+#include <cstring>
+
+// Static member initialization
+esp_ble_adv_data_t BleStream::adv_data = {};
+esp_ble_adv_params_t BleStream::adv_params = {
+    .adv_int_min = 0x20,
+    .adv_int_max = 0x40,
+    .adv_type = ADV_TYPE_IND,
+    .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    .peer_addr = {},
+    .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    .channel_map = ADV_CHNL_ALL,
+    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+};
+
+void BleStream::start() {
+    if (_isInitialized) {
+        return;
+    }
+
+    BLE_LOG_INFO("Starting BLE Stream initialization...");
+    esp_err_t ret;
+
+    // Release Classic BT memory (only if not already released)
+    static bool bt_mem_released = false;
+    if (!bt_mem_released) {
+        ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+        if (ret == ESP_OK) {
+            bt_mem_released = true;
+        } else {
+            BLE_LOG_ERROR("Failed to release Classic BT memory: " + std::string(esp_err_to_name(ret)));
+        }
+    }
+
+    // Initialize BT controller
+    esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+    ret = esp_bt_controller_init(&bt_cfg);
+    if (ret) {
+        BLE_LOG_ERROR("BLE controller init failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    ret = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+    if (ret) {
+        BLE_LOG_ERROR("BLE controller enable failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    // Initialize Bluedroid
+    ret = esp_bluedroid_init();
+    if (ret) {
+        BLE_LOG_ERROR("Bluedroid init failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    ret = esp_bluedroid_enable();
+    if (ret) {
+        BLE_LOG_ERROR("Bluedroid enable failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    // Register callbacks
+    ret = esp_ble_gatts_register_callback(gatts_event_handler);
+    if (ret) {
+        BLE_LOG_ERROR("GATTS register callback failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    ret = esp_ble_gap_register_callback(gap_event_handler);
+    if (ret) {
+        BLE_LOG_ERROR("GAP register callback failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    // Register GATT application
+    ret = esp_ble_gatts_app_register(0);
+    if (ret) {
+        BLE_LOG_ERROR("GATTS app register failed: " + std::string(esp_err_to_name(ret)));
+        return;
+    }
+
+    // Set MTU
+    esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
+    if (local_mtu_ret) {
+        BLE_LOG_ERROR("Set local MTU failed: " + std::string(esp_err_to_name(local_mtu_ret)));
+    }
+
+    _isInitialized = true;
+    BLE_LOG_INFO("BLE Stream initialized successfully");
+}
+
+bool BleStream::put(uint8_t c) {
+    std::array<uint8_t, 1> arr{c};
+    return write(std::span<const uint8_t>(arr)) == 1;
+}
+
+size_t BleStream::write(std::span<const uint8_t> data) {
+    if (!_isConnected || !_notifyEnabled) {
+        return data.size(); // Pretend write succeeded when not connected
+    }
+
+    size_t written = 0;
+    while (written < data.size()) {
+        size_t chunkSize = std::min(MAX_CHUNK_SIZE, data.size() - written);
+
+        esp_err_t ret = esp_ble_gatts_send_indicate(
+            gatts_if,
+            conn_id,
+            char_handle,
+            chunkSize,
+            const_cast<uint8_t*>(data.data() + written),
+            false // notification, not indication
+        );
+
+        if (ret != ESP_OK) {
+            BLE_LOG_ERROR("BLE notification failed: " + std::string(esp_err_to_name(ret)));
+            break;
+        }
+
+        written += chunkSize;
+
+        // Small delay to avoid overwhelming the BLE stack
+        if (written < data.size()) {
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+    }
+
+    return written;
+}
+
+int BleStream::get() {
+    std::lock_guard<std::mutex> lock(_bufferMutex);
+    if (_buffer.empty()) {
+        return -1;
+    }
+    uint8_t c = _buffer.front();
+    _buffer.pop_front();
+    return c;
+}
+
+size_t BleStream::read(std::span<uint8_t> data) {
+    std::lock_guard<std::mutex> lock(_bufferMutex);
+    size_t len = std::min(data.size(), _buffer.size());
+    std::copy_n(_buffer.begin(), len, data.begin());
+    _buffer.erase(_buffer.begin(), _buffer.begin() + len);
+    return len;
+}
+
+bool BleStream::flush() {
+    return true; // BLE notifications are sent immediately
+}
+
+void BleStream::onData(std::function<void(void)> callback) {
+    _onData = callback;
+}
+
+void BleStream::cleanup() {
+    if (_isInitialized) {
+        esp_bluedroid_disable();
+        esp_bluedroid_deinit();
+        esp_bt_controller_disable();
+        esp_bt_controller_deinit();
+        _isInitialized = false;
+    }
+}
+
+void BleStream::addReceivedData(const uint8_t* data, size_t len) {
+    {
+        std::lock_guard<std::mutex> lock(_bufferMutex);
+        _buffer.insert(_buffer.end(), data, data + len);
+    }
+
+    if (_onData) {
+        _onData();
+    }
+}
+
+std::string BleStream::generateDeviceName() {
+    uint8_t mac[6];
+    esp_err_t ret = esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    if (ret != ESP_OK) {
+        BLE_LOG_ERROR("Failed to read MAC address: " + std::string(esp_err_to_name(ret)));
+        return std::string(DEVICE_NAME_PREFIX);
+    }
+
+    // Use last 2 bytes of MAC address for uniqueness
+    char name_buffer[32];
+    snprintf(name_buffer, sizeof(name_buffer), "%s_%02X%02X",
+            DEVICE_NAME_PREFIX, mac[4], mac[5]);
+    return std::string(name_buffer);
+}
+
+void BleStream::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+    switch (event) {
+    case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT:
+        esp_ble_gap_start_advertising(&adv_params);
+        break;
+    case ESP_GAP_BLE_ADV_START_COMPLETE_EVT:
+        if (param->adv_start_cmpl.status != ESP_BT_STATUS_SUCCESS) {
+            BLE_LOG_ERROR("Advertising start failed with status: " + std::to_string(param->adv_start_cmpl.status));
+        } else {
+            BLE_LOG_INFO("BLE advertising started successfully! Device should be discoverable now.");
+        }
+        break;
+    case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT:
+        if (param->adv_stop_cmpl.status != ESP_BT_STATUS_SUCCESS) {
+            BLE_LOG_ERROR("Advertising stop failed");
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void BleStream::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if_param, esp_ble_gatts_cb_param_t *param) {
+    if (!instance) return;
+
+    switch (event) {
+    case ESP_GATTS_REG_EVT:
+        {
+            gatts_if = gatts_if_param;
+
+            // Generate device name with MAC address
+            std::string device_name = generateDeviceName();
+            esp_err_t set_dev_name_ret = esp_ble_gap_set_device_name(device_name.c_str());
+            if (set_dev_name_ret) {
+                BLE_LOG_ERROR("Set device name failed: " + std::string(esp_err_to_name(set_dev_name_ret)));
+            }
+
+            // Configure advertising data
+            esp_ble_adv_data_t adv_data = {
+                .set_scan_rsp = false,
+                .include_name = true,
+                .include_txpower = true,
+                .min_interval = 0x0006,
+                .max_interval = 0x0010,
+                .appearance = 0x00,
+                .manufacturer_len = 0,
+                .p_manufacturer_data = nullptr,
+                .service_data_len = 0,
+                .p_service_data = nullptr,
+                .service_uuid_len = 0,
+                .p_service_uuid = nullptr,
+                .flag = (ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT),
+            };
+
+            esp_err_t ret = esp_ble_gap_config_adv_data(&adv_data);
+            if (ret) {
+                BLE_LOG_ERROR("Config adv data failed: " + std::string(esp_err_to_name(ret)));
+            }
+
+            // Create service
+            esp_gatt_srvc_id_t service_id;
+            service_id.is_primary = true;
+            service_id.id.inst_id = 0x00;
+            service_id.id.uuid.len = ESP_UUID_LEN_16;
+            service_id.id.uuid.uuid.uuid16 = GATTS_SERVICE_UUID;
+            esp_err_t create_ret = esp_ble_gatts_create_service(gatts_if, &service_id, GATTS_NUM_HANDLE);
+            if (create_ret) {
+                BLE_LOG_ERROR("Create service failed: " + std::string(esp_err_to_name(create_ret)));
+            }
+            break;
+        }
+
+    case ESP_GATTS_CREATE_EVT:
+        {
+            service_handle = param->create.service_handle;
+
+            esp_err_t start_ret = esp_ble_gatts_start_service(service_handle);
+            if (start_ret) {
+                BLE_LOG_ERROR("Start service failed: " + std::string(esp_err_to_name(start_ret)));
+            }
+
+            // Add characteristic
+            esp_bt_uuid_t char_uuid = {
+                .len = ESP_UUID_LEN_16,
+                .uuid = {.uuid16 = GATTS_CHAR_UUID}
+            };
+
+            esp_gatt_char_prop_t char_property = ESP_GATT_CHAR_PROP_BIT_READ |
+                                                ESP_GATT_CHAR_PROP_BIT_WRITE |
+                                                ESP_GATT_CHAR_PROP_BIT_NOTIFY;
+
+            esp_err_t add_char_ret = esp_ble_gatts_add_char(service_handle, &char_uuid,
+                                 ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
+                                 char_property, nullptr, nullptr);
+            if (add_char_ret) {
+                BLE_LOG_ERROR("Add characteristic failed: " + std::string(esp_err_to_name(add_char_ret)));
+            }
+            break;
+        }
+
+    case ESP_GATTS_ADD_CHAR_EVT:
+        {
+            char_handle = param->add_char.attr_handle;
+
+            // Add descriptor for notifications
+            esp_bt_uuid_t descr_uuid = {
+                .len = ESP_UUID_LEN_16,
+                .uuid = {.uuid16 = GATTS_DESCR_UUID}
+            };
+
+            esp_err_t add_descr_ret = esp_ble_gatts_add_char_descr(service_handle, &descr_uuid,
+                                       ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
+                                       nullptr, nullptr);
+            if (add_descr_ret) {
+                BLE_LOG_ERROR("Add descriptor failed: " + std::string(esp_err_to_name(add_descr_ret)));
+            }
+            break;
+        }
+
+    case ESP_GATTS_ADD_CHAR_DESCR_EVT:
+        {
+            descr_handle = param->add_char_descr.attr_handle;
+            // Now that everything is set up, start advertising
+            esp_err_t adv_start_ret = esp_ble_gap_start_advertising(&adv_params);
+            if (adv_start_ret) {
+                BLE_LOG_ERROR("Failed to start advertising: " + std::string(esp_err_to_name(adv_start_ret)));
+            }
+            break;
+        }
+
+    case ESP_GATTS_START_EVT:
+        break;
+
+    case ESP_GATTS_CONNECT_EVT:
+        {
+            BLE_LOG_INFO("BLE client connected");
+            conn_id = param->connect.conn_id;
+            instance->_isConnected = true;
+
+            // Update connection parameters
+            esp_ble_conn_update_params_t conn_params = {};
+            memcpy(conn_params.bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
+            conn_params.latency = 0;
+            conn_params.max_int = 0x20;
+            conn_params.min_int = 0x10;
+            conn_params.timeout = 400;
+            esp_ble_gap_update_conn_params(&conn_params);
+            break;
+        }
+
+    case ESP_GATTS_DISCONNECT_EVT:
+        BLE_LOG_INFO("BLE client disconnected");
+        instance->_isConnected = false;
+        instance->_notifyEnabled = false;
+        esp_ble_gap_start_advertising(&adv_params);
+        break;
+
+    case ESP_GATTS_WRITE_EVT:
+        {
+            if (param->write.handle == descr_handle && param->write.len == 2) {
+                // Client Characteristic Configuration descriptor written
+                uint16_t descr_value = param->write.value[1] << 8 | param->write.value[0];
+                if (descr_value == 0x0001) {
+                    BLE_LOG_INFO("BLE notifications enabled");
+                    instance->_notifyEnabled = true;
+                } else {
+                    instance->_notifyEnabled = false;
+                }
+            } else if (param->write.handle == char_handle) {
+                // Data written to characteristic
+                instance->addReceivedData(param->write.value, param->write.len);
+            }
+
+            if (param->write.need_rsp) {
+                esp_ble_gatts_send_response(gatts_if, param->write.conn_id,
+                                          param->write.trans_id, ESP_GATT_OK, nullptr);
+            }
+            break;
+        }
+
+    case ESP_GATTS_READ_EVT:
+        {
+            // Respond to read requests with empty data
+            esp_gatt_rsp_t rsp = {};
+            rsp.attr_value.handle = param->read.handle;
+            rsp.attr_value.len = 0;
+            rsp.attr_value.value[0] = 0x00; // Set at least one byte
+
+            esp_err_t rsp_err = esp_ble_gatts_send_response(gatts_if, param->read.conn_id,
+                                      param->read.trans_id, ESP_GATT_OK, &rsp);
+            if (rsp_err != ESP_OK) {
+                BLE_LOG_ERROR("Failed to send read response: " + std::string(esp_err_to_name(rsp_err)));
+            }
+            break;
+        }
+
+    // Handle other events without error
+    case ESP_GATTS_EXEC_WRITE_EVT:
+    case ESP_GATTS_MTU_EVT:
+    case ESP_GATTS_CONF_EVT:
+    case ESP_GATTS_UNREG_EVT:
+    case ESP_GATTS_ADD_INCL_SRVC_EVT:
+    case ESP_GATTS_DELETE_EVT:
+    case ESP_GATTS_STOP_EVT:
+    case ESP_GATTS_OPEN_EVT:
+    case ESP_GATTS_CANCEL_OPEN_EVT:
+    case ESP_GATTS_CLOSE_EVT:
+    case ESP_GATTS_LISTEN_EVT:
+    case ESP_GATTS_CONGEST_EVT:
+    case ESP_GATTS_RESPONSE_EVT:
+    case ESP_GATTS_CREAT_ATTR_TAB_EVT:
+    case ESP_GATTS_SET_ATTR_VAL_EVT:
+    case ESP_GATTS_SEND_SERVICE_CHANGE_EVT:
+    default:
+        break;
+    }
+}

--- a/main/util/bleStream.h
+++ b/main/util/bleStream.h
@@ -1,0 +1,550 @@
+#pragma once
+
+#include <jac/link/stream.h>
+#include <jac/device/logger.h>
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <span>
+#include <string>
+#include <thread>
+#include <mutex>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_bt.h"
+#include "esp_bt_main.h"
+#include "esp_gap_ble_api.h"
+#include "esp_gatts_api.h"
+#include "esp_bt_defs.h"
+#include "esp_gatt_common_api.h"
+#include "nvs_flash.h"
+#include "esp_gap_ble_api.h"
+#include "esp_gatts_api.h"
+#include "esp_bt_defs.h"
+#include "esp_bt_main.h"
+#include "esp_gatt_common_api.h"
+
+// BLE Debug Logging Control
+// Uncomment the next line to enable detailed BLE logging for debugging
+// #define BLE_STREAM_DEBUG_LOGS
+
+#ifdef BLE_STREAM_DEBUG_LOGS
+    #define BLE_LOG_DEBUG(msg) jac::Logger::debug(msg)
+    #define BLE_LOG_ERROR(msg) jac::Logger::error(msg)
+    #define BLE_LOG_INFO(msg) jac::Logger::debug(msg)   // Use debug for info when enabled
+#else
+    #define BLE_LOG_DEBUG(msg) ((void)0)
+    #define BLE_LOG_ERROR(msg) jac::Logger::error(msg)  // Keep errors always visible
+    #define BLE_LOG_INFO(msg) ((void)0)                 // Disable info messages when debugging is off
+#endif
+
+
+class BleStream : public jac::Duplex {
+    std::function<void()> _onData;
+    std::deque<uint8_t> _buffer;
+    std::mutex _bufferMutex;
+    std::atomic<bool> _isConnected = false;
+    std::atomic<bool> _notifyEnabled = false;
+    std::atomic<bool> _isInitialized = false;
+
+    // BLE configuration
+    static constexpr uint16_t GATTS_SERVICE_UUID = 0x00FF;
+    static constexpr uint16_t GATTS_CHAR_UUID = 0xFF01;
+    static constexpr uint16_t GATTS_DESCR_UUID = 0x2902; // Client Characteristic Configuration
+    static constexpr uint16_t GATTS_NUM_HANDLE = 4;
+    static constexpr const char* DEVICE_NAME = "ESP32_JAC_BLE";
+
+    // BLE handles
+    static inline esp_gatt_if_t gatts_if = ESP_GATT_IF_NONE;
+    static inline uint16_t service_handle = 0;
+    static inline uint16_t char_handle = 0;
+    static inline uint16_t descr_handle = 0;
+    static inline uint16_t conn_id = 0;
+
+    // Global instance pointer for callbacks
+    static inline BleStream* instance = nullptr;
+
+    // BLE advertising data
+    static esp_ble_adv_data_t adv_data;
+    static esp_ble_adv_params_t adv_params;
+
+public:
+    BleStream(const std::string& deviceName = "BLE_STREAM") {
+        if (instance != nullptr) {
+            throw std::runtime_error("Only one BleStream instance is allowed");
+        }
+        instance = this;
+        // Note: deviceName could be used to customize the device name if needed
+    }
+
+    BleStream(BleStream&&) = delete;
+    BleStream(const BleStream&) = delete;
+    BleStream& operator=(BleStream&&) = delete;
+    BleStream& operator=(const BleStream&) = delete;
+
+    void start() {
+        if (_isInitialized) {
+            BLE_LOG_DEBUG("BLE Stream already initialized");
+            return;
+        }
+
+        BLE_LOG_INFO("Starting BLE Stream initialization...");
+        esp_err_t ret;
+
+        // Note: NVS is already initialized in main.cpp, so we skip it here
+        // Release Classic BT memory (only if not already released)
+        static bool bt_mem_released = false;
+        if (!bt_mem_released) {
+            BLE_LOG_DEBUG("Releasing Classic BT memory...");
+            ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+            if (ret == ESP_OK) {
+                bt_mem_released = true;
+                BLE_LOG_DEBUG("Classic BT memory released successfully");
+            } else {
+                BLE_LOG_ERROR("Failed to release Classic BT memory: " + std::string(esp_err_to_name(ret)));
+            }
+        } else {
+            BLE_LOG_DEBUG("Classic BT memory already released");
+        }
+
+        // Initialize BT controller
+        BLE_LOG_DEBUG("Initializing BT controller...");
+        esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+        ret = esp_bt_controller_init(&bt_cfg);
+        if (ret) {
+            BLE_LOG_ERROR("BLE controller init failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("BT controller initialized successfully");
+
+        BLE_LOG_DEBUG("Enabling BLE mode...");
+        ret = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+        if (ret) {
+            BLE_LOG_ERROR("BLE controller enable failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("BLE mode enabled successfully");
+
+        // Initialize Bluedroid
+        BLE_LOG_DEBUG("Initializing Bluedroid stack...");
+        ret = esp_bluedroid_init();
+        if (ret) {
+            BLE_LOG_ERROR("Bluedroid init failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("Bluedroid stack initialized successfully");
+
+        BLE_LOG_DEBUG("Enabling Bluedroid stack...");
+        ret = esp_bluedroid_enable();
+        if (ret) {
+            BLE_LOG_ERROR("Bluedroid enable failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("Bluedroid stack enabled successfully");
+
+        // Register callbacks
+        BLE_LOG_DEBUG("Registering GATTS callback...");
+        ret = esp_ble_gatts_register_callback(gatts_event_handler);
+        if (ret) {
+            BLE_LOG_ERROR("GATTS register callback failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("GATTS callback registered successfully");
+
+        BLE_LOG_DEBUG("Registering GAP callback...");
+        ret = esp_ble_gap_register_callback(gap_event_handler);
+        if (ret) {
+            BLE_LOG_ERROR("GAP register callback failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("GAP callback registered successfully");
+
+        // Register GATT application
+        BLE_LOG_DEBUG("Registering GATT application...");
+        ret = esp_ble_gatts_app_register(0);
+        if (ret) {
+            BLE_LOG_ERROR("GATTS app register failed: " + std::string(esp_err_to_name(ret)));
+            return;
+        }
+        BLE_LOG_DEBUG("GATT application registration initiated");
+
+        // Set MTU
+        esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
+        if (local_mtu_ret) {
+            BLE_LOG_ERROR("Set local MTU failed: " + std::string(esp_err_to_name(local_mtu_ret)));
+        }
+
+        _isInitialized = true;
+        BLE_LOG_INFO("BLE Stream initialized successfully");
+    }
+
+    bool put(uint8_t c) override {
+        return write(std::span<const uint8_t>(&c, 1)) == 1;
+    }
+
+    size_t write(std::span<const uint8_t> data) override {
+        if (!_isConnected || !_notifyEnabled) {
+            return data.size(); // Pretend write succeeded
+        }
+
+        // BLE has MTU limitations, so we may need to split large data
+        size_t written = 0;
+        const size_t maxChunkSize = 500; // Conservative MTU size
+
+        while (written < data.size()) {
+            size_t chunkSize = std::min(maxChunkSize, data.size() - written);
+
+            esp_err_t ret = esp_ble_gatts_send_indicate(
+                gatts_if,
+                conn_id,
+                char_handle,
+                chunkSize,
+                const_cast<uint8_t*>(data.data() + written),
+                false // notification, not indication
+            );
+
+            if (ret != ESP_OK) {
+                BLE_LOG_ERROR("BLE notification failed: " + std::string(esp_err_to_name(ret)));
+                break;
+            }
+
+            written += chunkSize;
+
+            // Small delay to avoid overwhelming the BLE stack
+            if (written < data.size()) {
+                vTaskDelay(pdMS_TO_TICKS(1));
+            }
+        }
+
+        return written;
+    }
+
+    int get() override {
+        std::lock_guard<std::mutex> lock(_bufferMutex);
+        if (_buffer.empty()) {
+            return -1;
+        }
+        uint8_t c = _buffer.front();
+        _buffer.pop_front();
+        return c;
+    }
+
+    size_t read(std::span<uint8_t> data) override {
+        std::lock_guard<std::mutex> lock(_bufferMutex);
+        size_t len = std::min(data.size(), _buffer.size());
+        std::copy_n(_buffer.begin(), len, data.begin());
+        _buffer.erase(_buffer.begin(), _buffer.begin() + len);
+        return len;
+    }
+
+    bool flush() override {
+        return true; // BLE notifications are sent immediately
+    }
+
+    void onData(std::function<void(void)> callback) override {
+        _onData = callback;
+    }
+
+    ~BleStream() override {
+        if (_isInitialized) {
+            esp_bluedroid_disable();
+            esp_bluedroid_deinit();
+            esp_bt_controller_disable();
+            esp_bt_controller_deinit();
+        }
+        if (instance == this) {
+            instance = nullptr;
+        }
+    }
+
+private:
+    // Add received data to buffer and trigger callback
+    void addReceivedData(const uint8_t* data, size_t len) {
+        {
+            std::lock_guard<std::mutex> lock(_bufferMutex);
+            _buffer.insert(_buffer.end(), data, data + len);
+        }
+
+        if (_onData) {
+            _onData();
+        }
+    }
+
+    // GAP event handler
+    static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+        BLE_LOG_DEBUG("GAP Event: " + std::to_string(event));
+
+        switch (event) {
+        case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT:
+            BLE_LOG_DEBUG("Advertisement data set complete, starting advertising...");
+            esp_ble_gap_start_advertising(&adv_params);
+            break;
+        case ESP_GAP_BLE_ADV_START_COMPLETE_EVT:
+            if (param->adv_start_cmpl.status != ESP_BT_STATUS_SUCCESS) {
+                BLE_LOG_ERROR("Advertising start failed with status: " + std::to_string(param->adv_start_cmpl.status));
+            } else {
+                BLE_LOG_INFO("BLE advertising started successfully! Device should be discoverable now.");
+            }
+            break;
+        case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT:
+            if (param->adv_stop_cmpl.status != ESP_BT_STATUS_SUCCESS) {
+                BLE_LOG_ERROR("Advertising stop failed");
+            } else {
+                BLE_LOG_DEBUG("BLE advertising stopped");
+            }
+            break;
+        default:
+            BLE_LOG_DEBUG("Unhandled GAP event: " + std::to_string(event));
+            break;
+        }
+    }
+
+    // GATTS event handler
+    static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if_param, esp_ble_gatts_cb_param_t *param) {
+        if (!instance) return;
+
+        BLE_LOG_DEBUG("GATTS Event: " + std::to_string(event));
+
+        switch (event) {
+        case ESP_GATTS_REG_EVT:
+            {
+                BLE_LOG_DEBUG("GATTS register event - Starting BLE service setup");
+                gatts_if = gatts_if_param;
+
+                BLE_LOG_DEBUG("Setting device name to: " + std::string(DEVICE_NAME));
+                esp_err_t set_dev_name_ret = esp_ble_gap_set_device_name(DEVICE_NAME);
+                if (set_dev_name_ret) {
+                    BLE_LOG_ERROR("Set device name failed: " + std::string(esp_err_to_name(set_dev_name_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Device name set successfully");
+                }
+
+                // Configure advertising data
+                esp_ble_adv_data_t adv_data = {
+                    .set_scan_rsp = false,
+                    .include_name = true,
+                    .include_txpower = true,
+                    .min_interval = 0x0006,
+                    .max_interval = 0x0010,
+                    .appearance = 0x00,
+                    .manufacturer_len = 0,
+                    .p_manufacturer_data = nullptr,
+                    .service_data_len = 0,
+                    .p_service_data = nullptr,
+                    .service_uuid_len = 0,
+                    .p_service_uuid = nullptr,
+                    .flag = (ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT),
+                };
+
+                BLE_LOG_DEBUG("Configuring advertisement data...");
+                esp_err_t ret = esp_ble_gap_config_adv_data(&adv_data);
+                if (ret) {
+                    BLE_LOG_ERROR("Config adv data failed: " + std::string(esp_err_to_name(ret)));
+                } else {
+                    BLE_LOG_DEBUG("Advertisement data configured successfully");
+                }
+
+                // Create service
+                BLE_LOG_DEBUG("Creating GATT service with UUID: 0x" + std::to_string(GATTS_SERVICE_UUID));
+                esp_gatt_srvc_id_t service_id;
+                service_id.is_primary = true;
+                service_id.id.inst_id = 0x00;
+                service_id.id.uuid.len = ESP_UUID_LEN_16;
+                service_id.id.uuid.uuid.uuid16 = GATTS_SERVICE_UUID;
+                esp_err_t create_ret = esp_ble_gatts_create_service(gatts_if, &service_id, GATTS_NUM_HANDLE);
+                if (create_ret) {
+                    BLE_LOG_ERROR("Create service failed: " + std::string(esp_err_to_name(create_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Service creation initiated");
+                }
+                break;
+            }
+
+        case ESP_GATTS_CREATE_EVT:
+            {
+                BLE_LOG_DEBUG("Service created with handle: " + std::to_string(param->create.service_handle));
+                service_handle = param->create.service_handle;
+
+                BLE_LOG_DEBUG("Starting service...");
+                esp_err_t start_ret = esp_ble_gatts_start_service(service_handle);
+                if (start_ret) {
+                    BLE_LOG_ERROR("Start service failed: " + std::string(esp_err_to_name(start_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Service start initiated");
+                }
+
+                // Add characteristic
+                BLE_LOG_DEBUG("Adding characteristic with UUID: 0x" + std::to_string(GATTS_CHAR_UUID));
+                esp_bt_uuid_t char_uuid = {
+                    .len = ESP_UUID_LEN_16,
+                    .uuid = {.uuid16 = GATTS_CHAR_UUID}
+                };
+
+                esp_gatt_char_prop_t char_property = ESP_GATT_CHAR_PROP_BIT_READ |
+                                                    ESP_GATT_CHAR_PROP_BIT_WRITE |
+                                                    ESP_GATT_CHAR_PROP_BIT_NOTIFY;
+
+                esp_err_t add_char_ret = esp_ble_gatts_add_char(service_handle, &char_uuid,
+                                     ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
+                                     char_property, nullptr, nullptr);
+                if (add_char_ret) {
+                    BLE_LOG_ERROR("Add characteristic failed: " + std::string(esp_err_to_name(add_char_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Characteristic addition initiated");
+                }
+                break;
+            }
+
+        case ESP_GATTS_ADD_CHAR_EVT:
+            {
+                BLE_LOG_DEBUG("Characteristic added with handle: " + std::to_string(param->add_char.attr_handle));
+                char_handle = param->add_char.attr_handle;
+
+                // Add descriptor for notifications
+                esp_bt_uuid_t descr_uuid = {
+                    .len = ESP_UUID_LEN_16,
+                    .uuid = {.uuid16 = GATTS_DESCR_UUID}
+                };
+
+                BLE_LOG_DEBUG("Adding descriptor for notifications...");
+                esp_err_t add_descr_ret = esp_ble_gatts_add_char_descr(service_handle, &descr_uuid,
+                                           ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
+                                           nullptr, nullptr);
+                if (add_descr_ret) {
+                    BLE_LOG_ERROR("Add descriptor failed: " + std::string(esp_err_to_name(add_descr_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Descriptor addition initiated");
+                }
+                break;
+            }
+
+        case ESP_GATTS_ADD_CHAR_DESCR_EVT:
+            {
+                BLE_LOG_DEBUG("Descriptor added with handle: " + std::to_string(param->add_char_descr.attr_handle));
+                descr_handle = param->add_char_descr.attr_handle;
+                // Now that everything is set up, start advertising
+                BLE_LOG_DEBUG("All services set up, starting BLE advertising...");
+                esp_err_t adv_start_ret = esp_ble_gap_start_advertising(&adv_params);
+                if (adv_start_ret) {
+                    BLE_LOG_ERROR("Failed to start advertising: " + std::string(esp_err_to_name(adv_start_ret)));
+                } else {
+                    BLE_LOG_DEBUG("Advertising start command sent successfully");
+                }
+                break;
+            }
+
+        case ESP_GATTS_START_EVT:
+            BLE_LOG_DEBUG("Service started");
+            break;
+
+        case ESP_GATTS_CONNECT_EVT:
+            {
+                BLE_LOG_INFO("BLE client connected");
+                conn_id = param->connect.conn_id;
+                instance->_isConnected = true;
+
+                // Update connection parameters
+                esp_ble_conn_update_params_t conn_params = {};
+                memcpy(conn_params.bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
+                conn_params.latency = 0;
+                conn_params.max_int = 0x20;
+                conn_params.min_int = 0x10;
+                conn_params.timeout = 400;
+                esp_ble_gap_update_conn_params(&conn_params);
+                break;
+            }
+
+        case ESP_GATTS_DISCONNECT_EVT:
+            BLE_LOG_INFO("BLE client disconnected");
+            instance->_isConnected = false;
+            instance->_notifyEnabled = false;
+            esp_ble_gap_start_advertising(&adv_params);
+            break;
+
+        case ESP_GATTS_WRITE_EVT:
+            {
+                if (param->write.handle == descr_handle && param->write.len == 2) {
+                    // Client Characteristic Configuration descriptor written
+                    uint16_t descr_value = param->write.value[1] << 8 | param->write.value[0];
+                    if (descr_value == 0x0001) {
+                        BLE_LOG_INFO("BLE notifications enabled");
+                        instance->_notifyEnabled = true;
+                    } else {
+                        BLE_LOG_DEBUG("BLE notifications disabled");
+                        instance->_notifyEnabled = false;
+                    }
+                } else if (param->write.handle == char_handle) {
+                    // Data written to characteristic
+                    BLE_LOG_DEBUG("Received " + std::to_string(param->write.len) + " bytes via BLE");
+                    instance->addReceivedData(param->write.value, param->write.len);
+                }
+
+                if (param->write.need_rsp) {
+                    esp_ble_gatts_send_response(gatts_if, param->write.conn_id,
+                                              param->write.trans_id, ESP_GATT_OK, nullptr);
+                }
+                break;
+            }
+
+        case ESP_GATTS_READ_EVT:
+            {
+                BLE_LOG_DEBUG("Read request for handle: " + std::to_string(param->read.handle));
+
+                // Respond to read requests with empty data
+                esp_gatt_rsp_t rsp = {};
+                rsp.attr_value.handle = param->read.handle;
+                rsp.attr_value.len = 0;
+                rsp.attr_value.value[0] = 0x00; // Set at least one byte
+
+                esp_err_t rsp_err = esp_ble_gatts_send_response(gatts_if, param->read.conn_id,
+                                          param->read.trans_id, ESP_GATT_OK, &rsp);
+                if (rsp_err != ESP_OK) {
+                    BLE_LOG_ERROR("Failed to send read response: " + std::string(esp_err_to_name(rsp_err)));
+                }
+                break;
+            }
+
+        // Handle other events without error
+        case ESP_GATTS_EXEC_WRITE_EVT:
+            BLE_LOG_DEBUG("GATTS Execute Write Event");
+            break;
+        case ESP_GATTS_MTU_EVT:
+            BLE_LOG_DEBUG("MTU updated to: " + std::to_string(param->mtu.mtu));
+            break;
+        case ESP_GATTS_CONF_EVT:
+            // Confirmation received for notification/indication
+            break;
+        case ESP_GATTS_UNREG_EVT:
+        case ESP_GATTS_ADD_INCL_SRVC_EVT:
+        case ESP_GATTS_DELETE_EVT:
+        case ESP_GATTS_STOP_EVT:
+        case ESP_GATTS_OPEN_EVT:
+        case ESP_GATTS_CANCEL_OPEN_EVT:
+        case ESP_GATTS_CLOSE_EVT:
+        case ESP_GATTS_LISTEN_EVT:
+        case ESP_GATTS_CONGEST_EVT:
+        case ESP_GATTS_RESPONSE_EVT:
+        case ESP_GATTS_CREAT_ATTR_TAB_EVT:
+        case ESP_GATTS_SET_ATTR_VAL_EVT:
+        case ESP_GATTS_SEND_SERVICE_CHANGE_EVT:
+        default:
+            break;
+        }
+    }
+};
+
+// Static member initialization
+esp_ble_adv_data_t BleStream::adv_data = {};
+esp_ble_adv_params_t BleStream::adv_params = {
+    .adv_int_min = 0x20,
+    .adv_int_max = 0x40,
+    .adv_type = ADV_TYPE_IND,
+    .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    .peer_addr = {},
+    .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    .channel_map = ADV_CHNL_ALL,
+    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+};

--- a/main/util/bleStream.h
+++ b/main/util/bleStream.h
@@ -25,10 +25,8 @@
 #include "esp_mac.h"
 
 // BLE Debug Logging Control
-// Uncomment the next line to enable detailed BLE logging for debugging
-// #define BLE_STREAM_DEBUG_LOGS
-
-#ifdef BLE_STREAM_DEBUG_LOGS
+// Can be controlled via Kconfig (menuconfig) or by defining BLE_STREAM_DEBUG_LOGS
+#if defined(CONFIG_JAC_ESP32_BLE_DEBUG_LOGS) || defined(BLE_STREAM_DEBUG_LOGS)
     #define BLE_LOG_DEBUG(msg) jac::Logger::debug(msg)
     #define BLE_LOG_ERROR(msg) jac::Logger::error(msg)
     #define BLE_LOG_INFO(msg) jac::Logger::debug(msg)   // Use debug for info when enabled
@@ -55,12 +53,12 @@ private:
     std::atomic<bool> _isInitialized{false};
 
     // BLE configuration constants
-    static constexpr uint16_t GATTS_SERVICE_UUID = 0x00FF;
-    static constexpr uint16_t GATTS_CHAR_UUID = 0xFF01;
+    static constexpr uint16_t GATTS_SERVICE_UUID = CONFIG_JAC_ESP32_BLE_SERVICE_UUID;
+    static constexpr uint16_t GATTS_CHAR_UUID = CONFIG_JAC_ESP32_BLE_CHARACTERISTIC_UUID;
     static constexpr uint16_t GATTS_DESCR_UUID = 0x2902; // Client Characteristic Configuration
     static constexpr uint16_t GATTS_NUM_HANDLE = 4;
-    static constexpr const char* DEVICE_NAME_PREFIX = "ESP32_JAC_BLE";
-    static constexpr size_t MAX_CHUNK_SIZE = 500; // Conservative MTU size
+    static constexpr const char* DEVICE_NAME_PREFIX = CONFIG_JAC_ESP32_BLE_DEVICE_NAME;
+    static constexpr size_t MAX_CHUNK_SIZE = CONFIG_JAC_ESP32_BLE_MTU_SIZE; // Configurable MTU size
 
     // BLE handles - shared across all instances
     static inline esp_gatt_if_t gatts_if = ESP_GATT_IF_NONE;

--- a/main/util/bleStream.h
+++ b/main/util/bleStream.h
@@ -11,6 +11,7 @@
 #include <span>
 #include <string>
 #include <mutex>
+#include <cstring>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -43,8 +44,6 @@
  * Provides a BLE GATT server that can be used as a duplex stream for communication.
  * Integrates with the Jaculus-esp32 project as an additional transport method.
  */
-
-
 class BleStream : public jac::Duplex {
 private:
     // Member variables
@@ -110,437 +109,39 @@ public:
      * @brief Initialize and start the BLE stack
      * @note This method is idempotent - calling it multiple times is safe
      */
-    void start() {
-        if (_isInitialized) {
-            return;
-        }
-
-        BLE_LOG_INFO("Starting BLE Stream initialization...");
-        esp_err_t ret;
-
-        // Release Classic BT memory (only if not already released)
-        static bool bt_mem_released = false;
-        if (!bt_mem_released) {
-            ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
-            if (ret == ESP_OK) {
-                bt_mem_released = true;
-            } else {
-                BLE_LOG_ERROR("Failed to release Classic BT memory: " + std::string(esp_err_to_name(ret)));
-            }
-        }
-
-        // Initialize BT controller
-        esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-        ret = esp_bt_controller_init(&bt_cfg);
-        if (ret) {
-            BLE_LOG_ERROR("BLE controller init failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        ret = esp_bt_controller_enable(ESP_BT_MODE_BLE);
-        if (ret) {
-            BLE_LOG_ERROR("BLE controller enable failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        // Initialize Bluedroid
-        ret = esp_bluedroid_init();
-        if (ret) {
-            BLE_LOG_ERROR("Bluedroid init failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        ret = esp_bluedroid_enable();
-        if (ret) {
-            BLE_LOG_ERROR("Bluedroid enable failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        // Register callbacks
-        ret = esp_ble_gatts_register_callback(gatts_event_handler);
-        if (ret) {
-            BLE_LOG_ERROR("GATTS register callback failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        ret = esp_ble_gap_register_callback(gap_event_handler);
-        if (ret) {
-            BLE_LOG_ERROR("GAP register callback failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        // Register GATT application
-        ret = esp_ble_gatts_app_register(0);
-        if (ret) {
-            BLE_LOG_ERROR("GATTS app register failed: " + std::string(esp_err_to_name(ret)));
-            return;
-        }
-
-        // Set MTU
-        esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
-        if (local_mtu_ret) {
-            BLE_LOG_ERROR("Set local MTU failed: " + std::string(esp_err_to_name(local_mtu_ret)));
-        }
-
-        _isInitialized = true;
-        BLE_LOG_INFO("BLE Stream initialized successfully");
-    }
+    void start();
 
     // Duplex interface implementation
-    bool put(uint8_t c) override {
-        std::array<uint8_t, 1> arr{c};
-        return write(std::span<const uint8_t>(arr)) == 1;
-    }
-
-    size_t write(std::span<const uint8_t> data) override {
-        if (!_isConnected || !_notifyEnabled) {
-            return data.size(); // Pretend write succeeded when not connected
-        }
-
-        size_t written = 0;
-        while (written < data.size()) {
-            size_t chunkSize = std::min(MAX_CHUNK_SIZE, data.size() - written);
-
-            esp_err_t ret = esp_ble_gatts_send_indicate(
-                gatts_if,
-                conn_id,
-                char_handle,
-                chunkSize,
-                const_cast<uint8_t*>(data.data() + written),
-                false // notification, not indication
-            );
-
-            if (ret != ESP_OK) {
-                BLE_LOG_ERROR("BLE notification failed: " + std::string(esp_err_to_name(ret)));
-                break;
-            }
-
-            written += chunkSize;
-
-            // Small delay to avoid overwhelming the BLE stack
-            if (written < data.size()) {
-                vTaskDelay(pdMS_TO_TICKS(1));
-            }
-        }
-
-        return written;
-    }
-
-    int get() override {
-        std::lock_guard<std::mutex> lock(_bufferMutex);
-        if (_buffer.empty()) {
-            return -1;
-        }
-        uint8_t c = _buffer.front();
-        _buffer.pop_front();
-        return c;
-    }
-
-    size_t read(std::span<uint8_t> data) override {
-        std::lock_guard<std::mutex> lock(_bufferMutex);
-        size_t len = std::min(data.size(), _buffer.size());
-        std::copy_n(_buffer.begin(), len, data.begin());
-        _buffer.erase(_buffer.begin(), _buffer.begin() + len);
-        return len;
-    }
-
-    bool flush() override {
-        return true; // BLE notifications are sent immediately
-    }
-
-    void onData(std::function<void(void)> callback) override {
-        _onData = callback;
-    }
+    bool put(uint8_t c) override;
+    size_t write(std::span<const uint8_t> data) override;
+    int get() override;
+    size_t read(std::span<uint8_t> data) override;
+    bool flush() override;
+    void onData(std::function<void(void)> callback) override;
 
 private:
     /**
      * @brief Clean up BLE resources
      */
-    void cleanup() {
-        if (_isInitialized) {
-            esp_bluedroid_disable();
-            esp_bluedroid_deinit();
-            esp_bt_controller_disable();
-            esp_bt_controller_deinit();
-            _isInitialized = false;
-        }
-    }
+    void cleanup();
 
     /**
-     * @brief Initialize the BT controller
-     * @return true on success, false on failure
+     * @brief Add received data to buffer and trigger callback
      */
-    bool initBtController();
+    void addReceivedData(const uint8_t* data, size_t len);
 
     /**
-     * @brief Initialize the Bluedroid stack
-     * @return true on success, false on failure
+     * @brief Generate device name with MAC address suffix
      */
-    bool initBluedroid();
+    static std::string generateDeviceName();
 
     /**
-     * @brief Register BLE callbacks
-     * @return true on success, false on failure
+     * @brief GAP event handler
      */
-    bool registerCallbacks();
+    static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
-    // Private method implementations
-    void addReceivedData(const uint8_t* data, size_t len) {
-        {
-            std::lock_guard<std::mutex> lock(_bufferMutex);
-            _buffer.insert(_buffer.end(), data, data + len);
-        }
-
-        if (_onData) {
-            _onData();
-        }
-    }
-
-    static std::string generateDeviceName() {
-        uint8_t mac[6];
-        esp_err_t ret = esp_read_mac(mac, ESP_MAC_WIFI_STA);
-        if (ret != ESP_OK) {
-            BLE_LOG_ERROR("Failed to read MAC address: " + std::string(esp_err_to_name(ret)));
-            return std::string(DEVICE_NAME_PREFIX);
-        }
-
-        // Use last 2 bytes of MAC address for uniqueness
-        char name_buffer[32];
-        snprintf(name_buffer, sizeof(name_buffer), "%s_%02X%02X",
-                DEVICE_NAME_PREFIX, mac[4], mac[5]);
-        return std::string(name_buffer);
-    }
-
-    // GAP event handler
-    static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-        switch (event) {
-        case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT:
-            esp_ble_gap_start_advertising(&adv_params);
-            break;
-        case ESP_GAP_BLE_ADV_START_COMPLETE_EVT:
-            if (param->adv_start_cmpl.status != ESP_BT_STATUS_SUCCESS) {
-                BLE_LOG_ERROR("Advertising start failed with status: " + std::to_string(param->adv_start_cmpl.status));
-            } else {
-                BLE_LOG_INFO("BLE advertising started successfully! Device should be discoverable now.");
-            }
-            break;
-        case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT:
-            if (param->adv_stop_cmpl.status != ESP_BT_STATUS_SUCCESS) {
-                BLE_LOG_ERROR("Advertising stop failed");
-            }
-            break;
-        default:
-            break;
-        }
-    }
-
-    // GATTS event handler
-    static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if_param, esp_ble_gatts_cb_param_t *param) {
-        if (!instance) return;
-
-        switch (event) {
-        case ESP_GATTS_REG_EVT:
-            {
-                gatts_if = gatts_if_param;
-
-                // Generate device name with MAC address
-                std::string device_name = generateDeviceName();
-                esp_err_t set_dev_name_ret = esp_ble_gap_set_device_name(device_name.c_str());
-                if (set_dev_name_ret) {
-                    BLE_LOG_ERROR("Set device name failed: " + std::string(esp_err_to_name(set_dev_name_ret)));
-                }
-
-                // Configure advertising data
-                esp_ble_adv_data_t adv_data = {
-                    .set_scan_rsp = false,
-                    .include_name = true,
-                    .include_txpower = true,
-                    .min_interval = 0x0006,
-                    .max_interval = 0x0010,
-                    .appearance = 0x00,
-                    .manufacturer_len = 0,
-                    .p_manufacturer_data = nullptr,
-                    .service_data_len = 0,
-                    .p_service_data = nullptr,
-                    .service_uuid_len = 0,
-                    .p_service_uuid = nullptr,
-                    .flag = (ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT),
-                };
-
-                esp_err_t ret = esp_ble_gap_config_adv_data(&adv_data);
-                if (ret) {
-                    BLE_LOG_ERROR("Config adv data failed: " + std::string(esp_err_to_name(ret)));
-                }
-
-                // Create service
-                esp_gatt_srvc_id_t service_id;
-                service_id.is_primary = true;
-                service_id.id.inst_id = 0x00;
-                service_id.id.uuid.len = ESP_UUID_LEN_16;
-                service_id.id.uuid.uuid.uuid16 = GATTS_SERVICE_UUID;
-                esp_err_t create_ret = esp_ble_gatts_create_service(gatts_if, &service_id, GATTS_NUM_HANDLE);
-                if (create_ret) {
-                    BLE_LOG_ERROR("Create service failed: " + std::string(esp_err_to_name(create_ret)));
-                }
-                break;
-            }
-
-        case ESP_GATTS_CREATE_EVT:
-            {
-                service_handle = param->create.service_handle;
-
-                esp_err_t start_ret = esp_ble_gatts_start_service(service_handle);
-                if (start_ret) {
-                    BLE_LOG_ERROR("Start service failed: " + std::string(esp_err_to_name(start_ret)));
-                }
-
-                // Add characteristic
-                esp_bt_uuid_t char_uuid = {
-                    .len = ESP_UUID_LEN_16,
-                    .uuid = {.uuid16 = GATTS_CHAR_UUID}
-                };
-
-                esp_gatt_char_prop_t char_property = ESP_GATT_CHAR_PROP_BIT_READ |
-                                                    ESP_GATT_CHAR_PROP_BIT_WRITE |
-                                                    ESP_GATT_CHAR_PROP_BIT_NOTIFY;
-
-                esp_err_t add_char_ret = esp_ble_gatts_add_char(service_handle, &char_uuid,
-                                     ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
-                                     char_property, nullptr, nullptr);
-                if (add_char_ret) {
-                    BLE_LOG_ERROR("Add characteristic failed: " + std::string(esp_err_to_name(add_char_ret)));
-                }
-                break;
-            }
-
-        case ESP_GATTS_ADD_CHAR_EVT:
-            {
-                char_handle = param->add_char.attr_handle;
-
-                // Add descriptor for notifications
-                esp_bt_uuid_t descr_uuid = {
-                    .len = ESP_UUID_LEN_16,
-                    .uuid = {.uuid16 = GATTS_DESCR_UUID}
-                };
-
-                esp_err_t add_descr_ret = esp_ble_gatts_add_char_descr(service_handle, &descr_uuid,
-                                           ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
-                                           nullptr, nullptr);
-                if (add_descr_ret) {
-                    BLE_LOG_ERROR("Add descriptor failed: " + std::string(esp_err_to_name(add_descr_ret)));
-                }
-                break;
-            }
-
-        case ESP_GATTS_ADD_CHAR_DESCR_EVT:
-            {
-                descr_handle = param->add_char_descr.attr_handle;
-                // Now that everything is set up, start advertising
-                esp_err_t adv_start_ret = esp_ble_gap_start_advertising(&adv_params);
-                if (adv_start_ret) {
-                    BLE_LOG_ERROR("Failed to start advertising: " + std::string(esp_err_to_name(adv_start_ret)));
-                }
-                break;
-            }
-
-        case ESP_GATTS_START_EVT:
-            break;
-
-        case ESP_GATTS_CONNECT_EVT:
-            {
-                BLE_LOG_INFO("BLE client connected");
-                conn_id = param->connect.conn_id;
-                instance->_isConnected = true;
-
-                // Update connection parameters
-                esp_ble_conn_update_params_t conn_params = {};
-                memcpy(conn_params.bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
-                conn_params.latency = 0;
-                conn_params.max_int = 0x20;
-                conn_params.min_int = 0x10;
-                conn_params.timeout = 400;
-                esp_ble_gap_update_conn_params(&conn_params);
-                break;
-            }
-
-        case ESP_GATTS_DISCONNECT_EVT:
-            BLE_LOG_INFO("BLE client disconnected");
-            instance->_isConnected = false;
-            instance->_notifyEnabled = false;
-            esp_ble_gap_start_advertising(&adv_params);
-            break;
-
-        case ESP_GATTS_WRITE_EVT:
-            {
-                if (param->write.handle == descr_handle && param->write.len == 2) {
-                    // Client Characteristic Configuration descriptor written
-                    uint16_t descr_value = param->write.value[1] << 8 | param->write.value[0];
-                    if (descr_value == 0x0001) {
-                        BLE_LOG_INFO("BLE notifications enabled");
-                        instance->_notifyEnabled = true;
-                    } else {
-                        instance->_notifyEnabled = false;
-                    }
-                } else if (param->write.handle == char_handle) {
-                    // Data written to characteristic
-                    instance->addReceivedData(param->write.value, param->write.len);
-                }
-
-                if (param->write.need_rsp) {
-                    esp_ble_gatts_send_response(gatts_if, param->write.conn_id,
-                                              param->write.trans_id, ESP_GATT_OK, nullptr);
-                }
-                break;
-            }
-
-        case ESP_GATTS_READ_EVT:
-            {
-                // Respond to read requests with empty data
-                esp_gatt_rsp_t rsp = {};
-                rsp.attr_value.handle = param->read.handle;
-                rsp.attr_value.len = 0;
-                rsp.attr_value.value[0] = 0x00; // Set at least one byte
-
-                esp_err_t rsp_err = esp_ble_gatts_send_response(gatts_if, param->read.conn_id,
-                                          param->read.trans_id, ESP_GATT_OK, &rsp);
-                if (rsp_err != ESP_OK) {
-                    BLE_LOG_ERROR("Failed to send read response: " + std::string(esp_err_to_name(rsp_err)));
-                }
-                break;
-            }
-
-        // Handle other events without error
-        case ESP_GATTS_EXEC_WRITE_EVT:
-        case ESP_GATTS_MTU_EVT:
-        case ESP_GATTS_CONF_EVT:
-        case ESP_GATTS_UNREG_EVT:
-        case ESP_GATTS_ADD_INCL_SRVC_EVT:
-        case ESP_GATTS_DELETE_EVT:
-        case ESP_GATTS_STOP_EVT:
-        case ESP_GATTS_OPEN_EVT:
-        case ESP_GATTS_CANCEL_OPEN_EVT:
-        case ESP_GATTS_CLOSE_EVT:
-        case ESP_GATTS_LISTEN_EVT:
-        case ESP_GATTS_CONGEST_EVT:
-        case ESP_GATTS_RESPONSE_EVT:
-        case ESP_GATTS_CREAT_ATTR_TAB_EVT:
-        case ESP_GATTS_SET_ATTR_VAL_EVT:
-        case ESP_GATTS_SEND_SERVICE_CHANGE_EVT:
-        default:
-            break;
-        }
-    }
-};
-
-// Static member initialization
-esp_ble_adv_data_t BleStream::adv_data = {};
-esp_ble_adv_params_t BleStream::adv_params = {
-    .adv_int_min = 0x20,
-    .adv_int_max = 0x40,
-    .adv_type = ADV_TYPE_IND,
-    .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
-    .peer_addr = {},
-    .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
-    .channel_map = ADV_CHNL_ALL,
-    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+    /**
+     * @brief GATTS event handler
+     */
+    static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if_param, esp_ble_gatts_cb_param_t *param);
 };


### PR DESCRIPTION
This pull request introduces BLE (Bluetooth Low Energy) support to the Jaculus ESP32 project, enabling it as an additional communication transport. The changes include updates to the build configuration, new BLE-specific functionality, and integration into the existing system. 

Using this feature, users can now connect to the Jaculus ESP32 device over BLE also from the Web Browser - tested with modified version of https://github.com/C2Coder/JacLy.
Online version is available at **https://f.kubaandrysek.cz/JacLy-BLE**. Tested with ESP32-S3.

Below is a summary of the most important changes:

### BLE Support Implementation

* **Added `BleStream` class**: Implemented a BLE GATT server in `main/util/bleStream.h` to provide duplex communication. The class includes features like configurable MTU size, device name generation, and event handling for GAP and GATTS. It integrates with the existing transport system as a new stream type.

* **Conditional BLE initialization**: Updated `main.cpp` to conditionally include and initialize the BLE stream based on the `CONFIG_JAC_ESP32_ENABLE_BLE` flag. This includes creating a BLE stream instance, starting it, and binding it to the multiplexer. [[1]](diffhunk://#diff-18b7c19417a461e4793bb2157831659d96ede991391e10ee5bc51f19453b7685R37-R39) [[2]](diffhunk://#diff-18b7c19417a461e4793bb2157831659d96ede991391e10ee5bc51f19453b7685R130-R132) [[3]](diffhunk://#diff-18b7c19417a461e4793bb2157831659d96ede991391e10ee5bc51f19453b7685R223-R233)

### Build System Enhancements

* **Refactored `CMakeLists.txt`**: Modularized the component registration process and added conditional inclusion of BLE-related files and dependencies. This ensures BLE support is included only when enabled via configuration.

* **Updated CMake version requirement**: Increased the minimum required version of CMake to 3.10 in `main/resources/CMakeLists.txt` to support newer features.

### Configuration Options

* **Added BLE configuration options**: Introduced a new menu in `main/Kconfig.projbuild` for configuring BLE features, including enabling/disabling BLE, setting the device name prefix, configuring GATT service/characteristic UUIDs, and specifying the MTU size. Debug logging for BLE operations can also be toggled.