### PR TITLE
feat: Add support for ADC2 and map ESP32-S3 ADC2 pins

### DIFF
--- a/main/espFeatures/adcFeature.h
+++ b/main/espFeatures/adcFeature.h
@@ -8,9 +8,7 @@
 
 #include "driver/adc.h"
 
-
-template<class Next>
-class AdcFeature : public Next {
+template <class Next> class AdcFeature : public Next {
     using PinConfig = Next::PlatformInfo::PinConfig;
 
     static std::pair<int, int> getAnalogPin(int pin) {
@@ -23,20 +21,34 @@ class AdcFeature : public Next {
     }
 
     class Adc {
-    public:
+      public:
         void configure(int pin, int atten = static_cast<int>(ADC_ATTEN_DB_12)) {
             int adcNum;
             int channel;
             std::tie(adcNum, channel) = getAnalogPin(pin);
 
-            esp_err_t err = adc1_config_width(static_cast<adc_bits_width_t>(ADC_WIDTH_BIT_DEFAULT));
-            if (err != ESP_OK) {
-                throw std::runtime_error(esp_err_to_name(err));
-            }
+            if (adcNum == 1) {
+                esp_err_t err = adc1_config_width(
+                    static_cast<adc_bits_width_t>(ADC_WIDTH_BIT_DEFAULT));
+                if (err != ESP_OK) {
+                    throw std::runtime_error(esp_err_to_name(err));
+                }
 
-            err = adc1_config_channel_atten(static_cast<adc1_channel_t>(channel), static_cast<adc_atten_t>(atten));
-            if (err != ESP_OK) {
-                throw std::runtime_error(esp_err_to_name(err));
+                err = adc1_config_channel_atten(
+                    static_cast<adc1_channel_t>(channel),
+                    static_cast<adc_atten_t>(atten));
+                if (err != ESP_OK) {
+                    throw std::runtime_error(esp_err_to_name(err));
+                }
+            } else if (adcNum == 2) {
+                esp_err_t err = adc2_config_channel_atten(
+                    static_cast<adc2_channel_t>(channel),
+                    static_cast<adc_atten_t>(atten));
+                if (err != ESP_OK) {
+                    throw std::runtime_error(esp_err_to_name(err));
+                }
+            } else {
+                throw std::runtime_error("Unsupported ADC unit");
             }
         }
 
@@ -45,39 +57,66 @@ class AdcFeature : public Next {
             int channel;
             std::tie(adcNum, channel) = getAnalogPin(pin);
 
-            return adc1_get_raw(static_cast<adc1_channel_t>(channel)) >> (ADC_WIDTH_BIT_DEFAULT - 10);
+            int raw_val = 0;
+
+            if (adcNum == 1) {
+                raw_val = adc1_get_raw(static_cast<adc1_channel_t>(channel));
+            } else if (adcNum == 2) {
+                esp_err_t err = adc2_get_raw(
+                    static_cast<adc2_channel_t>(channel),
+                    static_cast<adc_bits_width_t>(ADC_WIDTH_BIT_DEFAULT),
+                    &raw_val);
+                if (err != ESP_OK) {
+                    throw std::runtime_error(esp_err_to_name(err));
+                }
+            } else {
+                throw std::runtime_error("Unsupported ADC unit");
+            }
+
+            return raw_val >> (ADC_WIDTH_BIT_DEFAULT - 10);
         }
     };
 
-public:
+  public:
     Adc adc;
 
     void initialize() {
         Next::initialize();
 
         jac::FunctionFactory ff(this->context());
-        jac::Module& adcModule = this->newModule("adc");
+        jac::Module &adcModule = this->newModule("adc");
 
         jac::Object attten = jac::Object::create(this->context());
-        attten.defineProperty("Db0", jac::Value::from(this->context(), static_cast<int>(ADC_ATTEN_DB_0)));
-        attten.defineProperty("Db2_5", jac::Value::from(this->context(), static_cast<int>(ADC_ATTEN_DB_2_5)));
-        attten.defineProperty("Db6", jac::Value::from(this->context(), static_cast<int>(ADC_ATTEN_DB_6)));
-        attten.defineProperty("Db12", jac::Value::from(this->context(), static_cast<int>(ADC_ATTEN_DB_12)));
+        attten.defineProperty(
+            "Db0", jac::Value::from(this->context(),
+                                    static_cast<int>(ADC_ATTEN_DB_0)));
+        attten.defineProperty(
+            "Db2_5", jac::Value::from(this->context(),
+                                      static_cast<int>(ADC_ATTEN_DB_2_5)));
+        attten.defineProperty(
+            "Db6", jac::Value::from(this->context(),
+                                    static_cast<int>(ADC_ATTEN_DB_6)));
+        attten.defineProperty(
+            "Db12", jac::Value::from(this->context(),
+                                     static_cast<int>(ADC_ATTEN_DB_12)));
 
-        adcModule.addExport("configure", ff.newFunctionVariadic([this](std::vector<jac::ValueWeak> args) {
-            if (args.size() < 1 || args.size() > 2) {
-                throw std::runtime_error("Invalid number of arguments");
-            }
+        adcModule.addExport(
+            "configure",
+            ff.newFunctionVariadic([this](std::vector<jac::ValueWeak> args) {
+                if (args.size() < 1 || args.size() > 2) {
+                    throw std::runtime_error("Invalid number of arguments");
+                }
 
-            int pin = args[0].to<int>();
-            int atten = static_cast<int>(ADC_ATTEN_DB_12);
-            if (args.size() == 2) {
-                atten = args[1].to<int>();
-            }
+                int pin = args[0].to<int>();
+                int atten = static_cast<int>(ADC_ATTEN_DB_12);
+                if (args.size() == 2) {
+                    atten = args[1].to<int>();
+                }
 
-            adc.configure(pin, atten);
-        }));
-        adcModule.addExport("read", ff.newFunction(noal::function(&Adc::read, &adc)));
+                adc.configure(pin, atten);
+            }));
+        adcModule.addExport("read",
+                            ff.newFunction(noal::function(&Adc::read, &adc)));
         adcModule.addExport("Attenuation", attten);
     }
 };

--- a/main/platform/esp32s3.h
+++ b/main/platform/esp32s3.h
@@ -30,8 +30,19 @@ struct PlatformInfo {
             { 7, { 1, ADC1_GPIO7_CHANNEL } },
             { 8, { 1, ADC1_GPIO8_CHANNEL } },
             { 9, { 1, ADC1_GPIO9_CHANNEL } },
-            { 10, { 1, ADC1_GPIO10_CHANNEL } }
-        };
+            { 10, { 1, ADC1_GPIO10_CHANNEL } },
+
+            { 11, { 2, ADC2_GPIO11_CHANNEL } },
+            { 12, { 2, ADC2_GPIO12_CHANNEL } },
+            { 13, { 2, ADC2_GPIO13_CHANNEL } },
+            { 14, { 2, ADC2_GPIO14_CHANNEL } },
+            { 15, { 2, ADC2_GPIO15_CHANNEL } },
+            { 16, { 2, ADC2_GPIO16_CHANNEL } },
+            { 17, { 2, ADC2_GPIO17_CHANNEL } },
+            { 18, { 2, ADC2_GPIO18_CHANNEL } },
+            { 19, { 2, ADC2_GPIO19_CHANNEL } },
+            { 20, { 2, ADC2_GPIO20_CHANNEL } }
+        };      
         static inline const std::set<int> INTERRUPT_PINS = DIGITAL_PINS;
         static inline constexpr int DEFAULT_I2C_SDA_PIN = 0;
         static inline constexpr int DEFAULT_I2C_SCL_PIN = 1;


### PR DESCRIPTION
This change adds support for configuring and reading analog pins on the ADC2 unit. 

Previously, the ADC feature was restricted to ADC1 pins because the implementation only called `adc1_` driver helper functions, and the ESP32-S3 platform configuration only mapped ADC1 pins (GPIOs 1–10). This PR updates the driver and adds all remaining ADC2 pins to the platform configuration.

### Changes
* **Driver Support:** Branched `configure` and `read` methods in `AdcFeature` to use `adc2_config_channel_atten` and `adc2_get_raw` when the target pin belongs to ADC2.
* **Pin Mappings:** Added all ESP32-S3 ADC2 pins (GPIOs 11 through 20) to the `ANALOG_PINS` lookup map in the platform configuration.